### PR TITLE
Replace function only replaces one inline script

### DIFF
--- a/src/js/descript.js
+++ b/src/js/descript.js
@@ -192,6 +192,7 @@
         }
     };
 
+
     /**
      * Adds a new script searcher to match scripts in specific ways, such as by regex
      * @param name


### PR DESCRIPTION
`descript.replace` does not replace text across multiple inline scripts. This is a safety guard that is implemented in the descript replace function. We want to ensure there is no un-intentional inline script replacement. 

`descript.replace` doesn't allow more than 1 search type. For example, the following will not work:
```
descript.replace({
    contains: [
        'google',
        'bing'
    ]
})
```

However, in the following example, we have the following behaviour:

There are 2 scripts that contains an ID you need to replace:
```js
<script>
    ...
    var ID="123456789";
    var sID="123456789";
    ....
</script>
...
<script>
    ...
    var mob_ID="123456789"
    var tab_ID="123456789"
   ...
</script>
```
The following line will only replace all instance of the text of the second script and not the first script because descript works in reverse order.
```js
descript.replace({contains: '123456789'}, /123456789/g,'987654321');
```

I am not sure to call this a feature or a bug. We are making sure that we are replacing only one inline script at a time. However, it is confusing not knowing that the first script did not have replace performed.

**Question:**
Should we make replace function perform replacement to all inline script instance found with the single search type?

Status: **Opened for visibility**

Reviewers: @donnielrt @fractaltheory @jansepar 
JIRA: https://github.com/mobify/descript/issues/5

## Changes
- (change1)

## Notes
- (note1)