### PR TITLE
Add new searchers on init

### DIFF
--- a/src/js/descript.js
+++ b/src/js/descript.js
@@ -37,7 +37,7 @@
 
         this.options = $.extend(true, {}, Descript.DEFAULTS, options);
 
-        this.searchers = DEFAULT_SEARCHERS;
+        this.searchers = $.extend(true, {}, DEFAULT_SEARCHERS, options.searchers);
 
         this._buildDefaultContainer();
     };


### PR DESCRIPTION
Give init the ability to define new searchers so that it can be used with the preserve script list.

Status: **Ready to review**

Reviewers: @marlowpayne
## Changes
- You can now specify a new option `searchers` when initializing descript. This allows the new searcher function be available to use for the preserve script list.
## TO-DO
- [ ] Add documentation
- [ ] Add tests
- [ ] CI Test Passes
